### PR TITLE
Delete back button on More tab content

### DIFF
--- a/presentation/src/commonMain/kotlin/ireader/presentation/core/ui/MoreScreenSpec.kt
+++ b/presentation/src/commonMain/kotlin/ireader/presentation/core/ui/MoreScreenSpec.kt
@@ -47,7 +47,6 @@ object MoreScreenSpec : Tab {
         val navigator = LocalNavigator.currentOrThrow
         IScaffold(
             topBar = { scrollBehavior ->
-                // check if navigator backstack is empty
                 TitleToolbar(
                     title = localize(MR.strings.more),
                     scrollBehavior = scrollBehavior,

--- a/presentation/src/commonMain/kotlin/ireader/presentation/core/ui/MoreScreenSpec.kt
+++ b/presentation/src/commonMain/kotlin/ireader/presentation/core/ui/MoreScreenSpec.kt
@@ -47,12 +47,11 @@ object MoreScreenSpec : Tab {
         val navigator = LocalNavigator.currentOrThrow
         IScaffold(
             topBar = { scrollBehavior ->
+                // check if navigator backstack is empty
                 TitleToolbar(
                     title = localize(MR.strings.more),
                     scrollBehavior = scrollBehavior,
-                    popBackStack  = {
-                        popBackStack(navigator)
-                    },
+                    popBackStack = null,
                 )
             }
         ) { padding ->


### PR DESCRIPTION
**More** tab content seems like doesn't need a back button, only when popping into a new screen spec a back button is needed

This can make the UI more consistent as it will look the same with other tabs content (without a back button).