### PR TITLE
Fix dead spot when clicking on preset themes

### DIFF
--- a/presentation/src/commonMain/kotlin/ireader/presentation/ui/settings/appearance/AppearanceSettingScreen.kt
+++ b/presentation/src/commonMain/kotlin/ireader/presentation/ui/settings/appearance/AppearanceSettingScreen.kt
@@ -4,14 +4,35 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.border
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.BottomAppBar
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -24,13 +45,13 @@ import ireader.domain.utils.extensions.launchIO
 import ireader.i18n.UiText
 import ireader.i18n.resources.MR
 import ireader.presentation.ui.component.components.Build
-import ireader.presentation.ui.component.components.Components
-import ireader.presentation.ui.component.components.LazyColumnWithInsets
-import ireader.presentation.ui.component.components.Toolbar
 import ireader.presentation.ui.component.components.ChoicePreference
 import ireader.presentation.ui.component.components.ColorPickerDialog
 import ireader.presentation.ui.component.components.ColorPickerInfo
 import ireader.presentation.ui.component.components.ColorPreference
+import ireader.presentation.ui.component.components.Components
+import ireader.presentation.ui.component.components.LazyColumnWithInsets
+import ireader.presentation.ui.component.components.Toolbar
 import ireader.presentation.ui.component.reusable_composable.MidSizeTextComposable
 import ireader.presentation.ui.core.theme.AppColors
 import ireader.presentation.ui.core.theme.LocalLocalizeHelper
@@ -298,15 +319,15 @@ private fun ThemeItem(
                 ) {
                     Text("Text", fontSize = 11.sp, color = theme.materialColors.onBackground)
                     Button(
-                            onClick = {},
-                            enabled = false,
+                            onClick = { onClick(theme) },
+                            enabled = true,
                             contentPadding = PaddingValues(),
                             modifier = Modifier
                                     .align(Alignment.BottomStart)
                                     .size(40.dp, 20.dp),
                             content = {},
                             colors = ButtonDefaults.buttonColors(
-                                    disabledContainerColor = theme.materialColors.primary
+                                containerColor = theme.materialColors.primary
                             )
                     )
                     Surface(


### PR DESCRIPTION
A disabled button in the preview preset themes can lead to a deadspot that can confuse the user as to why the theme is not changing even when they think they clicked on it correctly.