### PR TITLE
Always follow user preferences default theme

### DIFF
--- a/android/src/main/java/org/ireader/app/MainActivity.kt
+++ b/android/src/main/java/org/ireader/app/MainActivity.kt
@@ -131,9 +131,27 @@ class MainActivity : ComponentActivity(), SecureActivityDelegate by SecureActivi
 
     @Composable
     private fun SetDefaultTheme() {
-        if (uiPreferences.themeMode().get() == PreferenceValues.ThemeMode.System) {
-            themes.find { it.isDark == isSystemInDarkTheme() }?.let { theme ->
-                uiPreferences.colorTheme().set(theme.id)
+        val themeMode by uiPreferences.themeMode().asStateIn(rememberCoroutineScope())
+        val isSystemDarkMode = isSystemInDarkTheme()
+        LaunchedEffect(themeMode) {
+            when (themeMode) {
+                PreferenceValues.ThemeMode.System -> {
+                    themes.find { it.isDark == isSystemDarkMode }?.let { theme ->
+                        uiPreferences.colorTheme().set(theme.id)
+                    }
+                }
+
+                PreferenceValues.ThemeMode.Dark -> {
+                    themes.find { it.isDark }?.let { theme ->
+                        uiPreferences.colorTheme().set(theme.id)
+                    }
+                }
+
+                PreferenceValues.ThemeMode.Light -> {
+                    themes.find { !it.isDark }?.let { theme ->
+                        uiPreferences.colorTheme().set(theme.id)
+                    }
+                }
             }
         }
     }

--- a/android/src/main/java/org/ireader/app/MainActivity.kt
+++ b/android/src/main/java/org/ireader/app/MainActivity.kt
@@ -134,6 +134,11 @@ class MainActivity : ComponentActivity(), SecureActivityDelegate by SecureActivi
         val themeMode by uiPreferences.themeMode().asStateIn(rememberCoroutineScope())
         val isSystemDarkMode = isSystemInDarkTheme()
         LaunchedEffect(themeMode) {
+            if (themes.firstOrNull { it.id == uiPreferences.colorTheme().get() } != null) {
+                return@LaunchedEffect
+            }
+
+
             when (themeMode) {
                 PreferenceValues.ThemeMode.System -> {
                     themes.find { it.isDark == isSystemDarkMode }?.let { theme ->

--- a/android/src/main/java/org/ireader/app/MainActivity.kt
+++ b/android/src/main/java/org/ireader/app/MainActivity.kt
@@ -7,10 +7,17 @@ import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.util.Consumer
 import androidx.core.view.WindowCompat
@@ -23,6 +30,7 @@ import coil3.compose.setSingletonImageLoaderFactory
 import io.github.aakira.napier.DebugAntilog
 import io.github.aakira.napier.Napier
 import ireader.core.http.toast
+import ireader.domain.models.prefs.PreferenceValues
 import ireader.domain.preferences.prefs.UiPreferences
 import ireader.domain.usecases.backup.AutomaticBackup
 import ireader.domain.usecases.files.AndroidGetSimpleStorage
@@ -42,6 +50,7 @@ import ireader.presentation.core.ui.DownloaderScreenSpec
 import ireader.presentation.core.ui.ReaderScreenSpec
 import ireader.presentation.core.ui.TTSScreenSpec
 import ireader.presentation.ui.component.IScaffold
+import ireader.presentation.ui.core.theme.themes
 import ireader.presentation.ui.core.ui.asStateIn
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.delay
@@ -75,7 +84,9 @@ class MainActivity : ComponentActivity(), SecureActivityDelegate by SecureActivi
         Napier.base(DebugAntilog())
         localeHelper.setLocaleLang()
         installSplashScreen()
+
         setContent {
+            SetDefaultTheme()
             KoinContext {
                 setSingletonImageLoaderFactory { context ->
                     (this@MainActivity.application as SingletonImageLoader.Factory).newImageLoader(
@@ -114,6 +125,15 @@ class MainActivity : ComponentActivity(), SecureActivityDelegate by SecureActivi
                     }
                 }
 
+            }
+        }
+    }
+
+    @Composable
+    private fun SetDefaultTheme() {
+        if (uiPreferences.themeMode().get() == PreferenceValues.ThemeMode.System) {
+            themes.find { it.isDark == isSystemInDarkTheme() }?.let { theme ->
+                uiPreferences.colorTheme().set(theme.id)
             }
         }
     }


### PR DESCRIPTION
When changing the theme mode in the appearance screen, the ID of preset themes that were used in the previous theme mode is lost. This is a bug that needs to be fixed.

My approach is to set the id whenever themeMode changes.