### PR TITLE
fix: TTS auto-next freezes when the next chapter has no fetched content yet

### DIFF
--- a/domain/src/commonMain/kotlin/ireader/domain/services/tts_service/v2/TTSController.kt
+++ b/domain/src/commonMain/kotlin/ireader/domain/services/tts_service/v2/TTSController.kt
@@ -45,6 +45,13 @@ class TTSController(
     private var gradioConfig: GradioConfig? = initialGradioConfig
     companion object {
         private const val TAG = "TTSController"
+
+        // Bounds for the auto-next empty-content watch (issue #236). Poll loadChapter
+        // with exponential backoff until the next chapter's content is fetched, giving
+        // up after the timeout so the coroutine never leaks.
+        private const val CHAPTER_CONTENT_WATCH_TIMEOUT_MS = 5 * 60 * 1000L
+        private const val CHAPTER_CONTENT_WATCH_INITIAL_DELAY_MS = 500L
+        private const val CHAPTER_CONTENT_WATCH_MAX_DELAY_MS = 5_000L
     }
 
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
@@ -623,7 +630,26 @@ class TTSController(
             if (nextChapterId != null) {
                 Log.debug { "$TAG: Loading next chapter: $nextChapterId" }
                 loadChapter(book.id, nextChapterId, 0)
-                if (wasPlaying) { play() }
+
+                if (_state.value.hasContent) {
+                    // Content is present (already in DB or fetched synchronously by
+                    // loadChapter) — resume playback as before.
+                    if (wasPlaying) { play() }
+                } else if (_state.value.autoNextChapter) {
+                    // The next chapter row exists but its content has not been fetched
+                    // yet (empty paragraphs after loadChapter, e.g. the remote fetch is
+                    // still in flight). Calling play() here would short-circuit on
+                    // TTSError.NoContent and leave playback stuck with a perpetual
+                    // loading bar (issue #236). Instead, watch this chapter for content
+                    // and resume once it arrives.
+                    Log.debug { "$TAG: Next chapter $nextChapterId has no content yet, watching for content (autoNext=true)" }
+                    startChapterContentWatch(book.id, nextChapterId, wasPlaying)
+                } else {
+                    // Auto-next disabled and no content — settle cleanly to STOPPED
+                    // rather than erroring or staying stuck in LOADING.
+                    Log.debug { "$TAG: Next chapter $nextChapterId has no content and autoNext is off, stopping" }
+                    _state.update { it.copy(playbackState = PlaybackState.STOPPED) }
+                }
             } else if (_state.value.autoNextChapter) {
                 // Next chapter not in DB yet — watch for new chapters from remote fetch
                 Log.debug { "$TAG: No next chapter in DB, watching for chapter DB changes (autoNext=true)" }
@@ -682,6 +708,95 @@ class TTSController(
             } catch (e: Exception) {
                 Log.error { "$TAG: nextChapterWatch failed: ${e.message}" }
                 handleError(TTSError.ContentLoadFailed(e.message ?: "Chapter watch failed"))
+            } finally {
+                nextChapterWatchJob = null
+            }
+        }
+    }
+
+    /**
+     * Watch a chapter that already exists in the DB but whose content has not been
+     * fetched yet, and resume playback once its content becomes available.
+     *
+     * This covers the auto-next case (issue #236) where getNextChapterId returns a
+     * chapter row but loadChapter produced no paragraphs because the remote fetch is
+     * still in flight. Without this, nextChapter() would call play() on empty content
+     * and short-circuit on TTSError.NoContent, leaving playback stuck in a perpetual
+     * loading state.
+     *
+     * Implementation note: we intentionally poll contentLoader.loadChapter rather than
+     * subscribing to the chapter list. The production subscribeChapters stream is keyed
+     * on chapter IDs (distinctUntilChangedBy { it.id }) and does NOT re-emit when an
+     * existing row simply gains content, so it cannot detect this transition. loadChapter
+     * itself re-attempts the remote fetch on empty content, so re-invoking it with backoff
+     * both drives the fetch and observes when content lands. Resume is dispatched through
+     * the commandMutex (via TTSCommand) so state mutations stay serialized with
+     * user-initiated commands, and the current playback state is re-checked at resolution
+     * time so a pause/stop issued while waiting is respected.
+     */
+    private fun startChapterContentWatch(bookId: Long, chapterId: Long, wasPlaying: Boolean) {
+        nextChapterWatchJob?.cancel()
+        nextChapterWatchJob = scope.launch {
+            try {
+                kotlinx.coroutines.withTimeout(CHAPTER_CONTENT_WATCH_TIMEOUT_MS) {
+                    var delayMs = CHAPTER_CONTENT_WATCH_INITIAL_DELAY_MS
+                    while (true) {
+                        kotlinx.coroutines.delay(delayMs)
+
+                        // If the user navigated elsewhere while waiting, abort the watch.
+                        if (_state.value.chapter?.id != chapterId) {
+                            Log.debug { "$TAG: chapterContentWatch - chapter changed while waiting, aborting" }
+                            return@withTimeout
+                        }
+
+                        val content = contentLoader.loadChapter(bookId, chapterId)
+
+                        // loadChapter suspends while fetching; re-check that the user is
+                        // still on this chapter afterwards. If they navigated elsewhere
+                        // during the fetch, drop the now-stale result instead of yanking
+                        // playback back to the old auto-next chapter.
+                        if (_state.value.chapter?.id != chapterId) {
+                            Log.debug { "$TAG: chapterContentWatch - chapter changed during fetch, dropping stale result" }
+                            return@withTimeout
+                        }
+
+                        if (content.paragraphs.isNotEmpty()) {
+                            Log.debug { "$TAG: Chapter $chapterId content arrived, resuming playback" }
+
+                            // Re-load to pull the now-available content into state, then
+                            // resume only if playback wasn't paused/stopped while waiting.
+                            // Read the live state at resolution time (not watch-start) so a
+                            // pause issued during the wait (e.g. audio-focus loss) is honored.
+                            dispatch(TTSCommand.LoadChapter(bookId, chapterId, 0))
+                            val shouldResume = wasPlaying &&
+                                _state.value.playbackState != PlaybackState.PAUSED &&
+                                _state.value.playbackState != PlaybackState.STOPPED
+                            if (shouldResume) {
+                                dispatch(TTSCommand.Play)
+                            }
+                            return@withTimeout
+                        }
+
+                        // Exponential backoff, capped, to avoid hammering the source.
+                        delayMs = (delayMs * 2).coerceAtMost(CHAPTER_CONTENT_WATCH_MAX_DELAY_MS)
+                    }
+                }
+            } catch (_: kotlinx.coroutines.TimeoutCancellationException) {
+                Log.debug { "$TAG: chapterContentWatch timed out, content never arrived for $chapterId" }
+                // Only settle to STOPPED if the user is still on the watched chapter — a
+                // late timeout must not clobber playback the user has since started elsewhere.
+                if (_state.value.chapter?.id == chapterId) {
+                    _state.update { it.copy(playbackState = PlaybackState.STOPPED) }
+                }
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.error { "$TAG: chapterContentWatch failed: ${e.message}" }
+                // Same guard: don't surface this watch's error onto an unrelated chapter
+                // the user navigated to while the watch was pending.
+                if (_state.value.chapter?.id == chapterId) {
+                    handleError(TTSError.ContentLoadFailed(e.message ?: "Chapter content watch failed"))
+                }
             } finally {
                 nextChapterWatchJob = null
             }

--- a/domain/src/commonTest/kotlin/ireader/domain/services/tts_service/TTSChapterChangeTest.kt
+++ b/domain/src/commonTest/kotlin/ireader/domain/services/tts_service/TTSChapterChangeTest.kt
@@ -1,10 +1,25 @@
 package ireader.domain.services.tts_service
 
+import ireader.domain.models.entities.Book
 import ireader.domain.models.entities.Chapter
+import ireader.domain.services.tts_service.v2.EngineEvent
+import ireader.domain.services.tts_service.v2.PlaybackState
+import ireader.domain.services.tts_service.v2.TTSCommand
+import ireader.domain.services.tts_service.v2.TTSContentLoader
+import ireader.domain.services.tts_service.v2.TTSController
+import ireader.domain.services.tts_service.v2.TTSEngine
+import ireader.domain.services.tts_service.v2.TTSError
 import ireader.core.source.model.Text
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -319,6 +334,218 @@ class TTSChapterChangeTest {
         val shouldAutoNext = isAtEnd && state.autoNextChapter.value && hasNextChapter
         
         assertTrue(shouldAutoNext, "Should trigger auto-next chapter")
+    }
+
+    /**
+     * Regression test for issue #236 (and its duplicate #235).
+     *
+     * Auto-next to a chapter that already has content in the DB must play immediately
+     * and must NOT route into the empty-content watch path or emit TTSError.NoContent.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `auto-next with content plays immediately without NoContent`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(dispatcher)
+        try {
+            val loader = ContentAwareLoader()
+            loader.contentByChapter[1L] = listOf("C1 P1", "C1 P2")
+            loader.contentByChapter[2L] = listOf("C2 P1", "C2 P2") // next chapter already has content
+            loader.nextChapterIdValue = 2L
+
+            val engine = RecordingEngine()
+            val controller = TTSController(
+                contentLoader = loader,
+                nativeEngineFactory = { engine }
+            )
+
+            controller.dispatch(TTSCommand.Initialize)
+            controller.dispatch(TTSCommand.LoadChapter(bookId = 1, chapterId = 1, startParagraph = 0))
+            controller.dispatch(TTSCommand.Play)
+            testScheduler.advanceUntilIdle()
+
+            controller.dispatch(TTSCommand.NextChapter)
+            testScheduler.advanceUntilIdle()
+
+            val state = controller.state.value
+            assertEquals(2L, state.chapter?.id, "Should have advanced to chapter 2")
+            assertTrue(state.hasContent, "Chapter 2 content should be loaded")
+            assertFalse(state.error is TTSError.NoContent, "Must not emit NoContent on a chapter with content")
+            assertEquals(2, state.totalParagraphs, "Chapter 2 paragraphs should be loaded")
+
+            controller.destroy()
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+
+    /**
+     * Regression test for issue #236: auto-next where the next chapter row exists in the
+     * DB but its content has not been fetched yet (empty paragraphs after loadChapter).
+     *
+     * Before the fix, nextChapter() unconditionally called play() on the empty chapter,
+     * which short-circuited on TTSError.NoContent and left playback stuck with a
+     * perpetual loading bar. After the fix, the controller must NOT emit NoContent and
+     * must resume playback once the content arrives in the DB.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `auto-next with empty next chapter does not emit NoContent and resumes when content arrives`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(dispatcher)
+        try {
+            val loader = ContentAwareLoader()
+            loader.contentByChapter[1L] = listOf("C1 P1", "C1 P2")
+            // Chapter 2 exists but its content is not fetched yet: the first loadChapter
+            // (from nextChapter) returns empty, then a later poll returns content,
+            // modelling a remote fetch that lands while the watch is waiting.
+            loader.pendingChapterId = 2L
+            loader.emptyCallsBeforeContent = 1
+            loader.pendingContent = listOf("C2 P1", "C2 P2")
+            loader.nextChapterIdValue = 2L
+
+            val engine = RecordingEngine()
+            val controller = TTSController(
+                contentLoader = loader,
+                nativeEngineFactory = { engine }
+            )
+            controller.dispatch(TTSCommand.SetAutoNextChapter(true))
+            controller.dispatch(TTSCommand.Initialize)
+            controller.dispatch(TTSCommand.LoadChapter(bookId = 1, chapterId = 1, startParagraph = 0))
+            controller.dispatch(TTSCommand.Play)
+            testScheduler.advanceUntilIdle()
+
+            controller.dispatch(TTSCommand.NextChapter)
+            // Process the synchronous part of nextChapter (empty loadChapter + start watch)
+            // without advancing virtual time, so we observe the pre-content-arrival state.
+            testScheduler.runCurrent()
+
+            // The next chapter has no content yet: must NOT have errored with NoContent.
+            val watching = controller.state.value
+            assertFalse(watching.error is TTSError.NoContent, "Must not emit NoContent while content is still being fetched")
+            assertFalse(watching.playbackState == PlaybackState.ERROR, "Must not be in ERROR state while content is being fetched")
+
+            // Let the content-watch poll run; content arrives on the next poll.
+            testScheduler.advanceUntilIdle()
+
+            val resumed = controller.state.value
+            assertEquals(2L, resumed.chapter?.id, "Should have advanced to chapter 2 once content arrived")
+            assertTrue(resumed.hasContent, "Chapter 2 content should now be loaded")
+            assertFalse(resumed.error is TTSError.NoContent, "Must never emit NoContent for an auto-advanced chapter")
+
+            controller.destroy()
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+
+    /**
+     * Regression test for issue #236: auto-next disabled with an empty next chapter must
+     * settle cleanly to STOPPED rather than erroring or staying stuck in LOADING.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `next chapter with empty content and autoNext off settles to stopped`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(dispatcher)
+        try {
+            val loader = ContentAwareLoader()
+            loader.contentByChapter[1L] = listOf("C1 P1", "C1 P2")
+            loader.contentByChapter[2L] = emptyList()
+            loader.nextChapterIdValue = 2L
+
+            val engine = RecordingEngine()
+            val controller = TTSController(
+                contentLoader = loader,
+                nativeEngineFactory = { engine }
+            )
+            controller.dispatch(TTSCommand.SetAutoNextChapter(false))
+            controller.dispatch(TTSCommand.Initialize)
+            controller.dispatch(TTSCommand.LoadChapter(bookId = 1, chapterId = 1, startParagraph = 0))
+            controller.dispatch(TTSCommand.Play)
+            testScheduler.advanceUntilIdle()
+
+            controller.dispatch(TTSCommand.NextChapter)
+            testScheduler.advanceUntilIdle()
+
+            val state = controller.state.value
+            assertFalse(state.error is TTSError.NoContent, "Must not emit NoContent with autoNext off")
+            assertEquals(PlaybackState.STOPPED, state.playbackState, "Should settle to STOPPED")
+
+            controller.destroy()
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+
+    /**
+     * Content-aware mock loader: chapter content is looked up from a mutable map so a test
+     * can model a chapter row that exists with empty content and later gains content.
+     * subscribeChapters emits a MutableStateFlow the test can update to simulate a remote
+     * fetch landing in the DB.
+     */
+    private class ContentAwareLoader : TTSContentLoader {
+        val contentByChapter = mutableMapOf<Long, List<String>>()
+        var nextChapterIdValue: Long? = null
+        var previousChapterIdValue: Long? = null
+        val chaptersFlow = MutableStateFlow<List<Chapter>>(emptyList())
+
+        /**
+         * Models a chapter whose remote content fetch is still in flight: loadChapter
+         * for [pendingChapterId] returns empty until it has been called
+         * [emptyCallsBeforeContent] times, then returns [pendingContent]. This mirrors
+         * TTSContentLoaderImpl, where loadChapter itself drives the remote fetch and
+         * eventually returns content once it lands.
+         */
+        var pendingChapterId: Long? = null
+        var emptyCallsBeforeContent: Int = 0
+        var pendingContent: List<String> = emptyList()
+        private var pendingCalls = 0
+
+        override suspend fun loadChapter(bookId: Long, chapterId: Long): TTSContentLoader.ChapterContent {
+            val paragraphs = if (chapterId == pendingChapterId) {
+                pendingCalls++
+                if (pendingCalls > emptyCallsBeforeContent) pendingContent else emptyList()
+            } else {
+                contentByChapter[chapterId] ?: emptyList()
+            }
+            return TTSContentLoader.ChapterContent(
+                book = Book(id = bookId, title = "Test Book", key = "test", sourceId = 1),
+                chapter = Chapter(id = chapterId, bookId = bookId, key = "ch$chapterId", name = "Chapter $chapterId"),
+                paragraphs = paragraphs
+            )
+        }
+
+        override suspend fun getNextChapterId(bookId: Long, currentChapterId: Long): Long? = nextChapterIdValue
+
+        override suspend fun getPreviousChapterId(bookId: Long, currentChapterId: Long): Long? = previousChapterIdValue
+
+        override fun subscribeChapters(bookId: Long): Flow<List<Chapter>> = chaptersFlow
+    }
+
+    /**
+     * Minimal recording TTS engine for controller-level tests. Uses replay = 1 so the
+     * controller's event collector reliably observes the latest Started event regardless
+     * of the order in which the collector subscribes relative to speak() under the test
+     * dispatcher (with replay = 0 the Started could be emitted before the collector
+     * subscribes and be lost, leaving the controller stuck in LOADING).
+     */
+    private class RecordingEngine : TTSEngine {
+        private val _events = MutableSharedFlow<EngineEvent>(replay = 1, extraBufferCapacity = 10)
+        override val events: Flow<EngineEvent> = _events
+        override val name: String = "Recording Engine"
+
+        override suspend fun speak(text: String, utteranceId: String) {
+            _events.emit(EngineEvent.Started(utteranceId))
+        }
+
+        override fun stop() {}
+        override fun pause() {}
+        override fun resume() {}
+        override fun setSpeed(speed: Float) {}
+        override fun setPitch(pitch: Float) {}
+        override fun isReady() = true
+        override fun release() {}
     }
 
     // Helper function to create test chapters


### PR DESCRIPTION
## Summary

Fixes the TTS auto-next freeze where, with "auto next chapter" enabled, playback reads the first syllable of the new chapter and then immediately stops with a perpetual loading bar in the notification.

The root cause is in `TTSController.nextChapter()`. When `getNextChapterId(...)` returns a chapter that already exists as a row in the DB, the code calls `loadChapter(...)` and then unconditionally calls `play()`. But `play()` short-circuits at its very first line:

```kotlin
if (!currentState.hasContent) { handleError(TTSError.NoContent); return }
```

So when the next chapter row exists but its content has not been fetched yet (empty paragraphs right after `loadChapter`, e.g. the remote fetch is still in flight), playback drops into the `NoContent` error state and stops, leaving the loading bar stuck.

This PR makes the in-DB branch of `nextChapter()` content-aware:

- If the loaded next chapter has content, play immediately (unchanged behavior).
- If it has no content yet and auto-next is on, start a bounded content watch that polls `loadChapter` with exponential backoff (which itself drives the remote fetch) and resumes playback once content lands, instead of erroring out.
- If it has no content and auto-next is off, settle cleanly to `STOPPED` rather than erroring or staying stuck in `LOADING`.

The watch re-checks the active chapter both before and after the suspending fetch and scopes its terminal (timeout/error) state updates to the watched chapter, so a user who navigates away while the watch is pending is never yanked back or interrupted.

Note: the watch intentionally polls `loadChapter` rather than subscribing to `subscribeChapters`, because the production `subscribeChapters` stream is keyed on chapter IDs (`distinctUntilChangedBy { it.id }`) and does not re-emit when an existing row merely gains content.

## Why this matters

This is the empty-next-chapter-content case that remained unhandled after the earlier transition mitigations (the `delay(150)` after `engine.stop()` and the command-mutex serialization). The reporter narrowed the cause on 2026-06-18 — the transition stalls precisely when the new chapter briefly flashes "no content available" before its content loads — and the maintainer confirmed the same root cause in the thread. This change addresses that specific path.

This also resolves the duplicate report in #235 (TTS freezes on next chapter), which describes the same freeze.

## Testing

Added three controller-level regression tests to `TTSChapterChangeTest.kt`, driving the real `TTSController` with mock content loader/engine:

- Auto-next to a chapter that already has content plays immediately and never emits `TTSError.NoContent`.
- Auto-next where the next chapter row exists but its content is not fetched yet does not emit `NoContent`, and resumes playback once the content arrives.
- Auto-next disabled with an empty next chapter settles to `STOPPED` rather than erroring.

All `TTSChapterChangeTest` (16) and `TTSControllerTest` (7) tests pass via `:domain:desktopTest`.

Fixes #236


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent waiting mechanism for auto-next when chapter content is still loading

* **Bug Fixes**
  * Fixed race condition in chapter transitions when next chapter content isn't immediately available
  * Prevented controller from getting stuck in loading state during auto-next operations
  * Improved state handling when auto-next is disabled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->