### PR TITLE
fix: make app-update broadcasts package-explicit so download progress isn't stuck at 0%

### DIFF
--- a/domain/src/androidMain/kotlin/ireader/domain/services/update_service/AppUpdateDownloadService.kt
+++ b/domain/src/androidMain/kotlin/ireader/domain/services/update_service/AppUpdateDownloadService.kt
@@ -155,6 +155,7 @@ class AppUpdateDownloadService : Service() {
             try {
                 // Broadcast connecting state
                 val connectingIntent = Intent("ireader.UPDATE_DOWNLOAD_CONNECTING").apply {
+                    setPackage(packageName)
                     putExtra("version", version)
                 }
                 sendBroadcast(connectingIntent)
@@ -190,6 +191,7 @@ class AppUpdateDownloadService : Service() {
                     // Send immediate 0% progress update
                     try {
                         val initialProgressIntent = Intent("ireader.UPDATE_DOWNLOAD_PROGRESS").apply {
+                            setPackage(packageName)
                             putExtra("progress", 0f)
                             putExtra("version", version)
                         }
@@ -244,6 +246,7 @@ class AppUpdateDownloadService : Service() {
                                     // Broadcast progress
                                     try {
                                         val progressIntent = Intent("ireader.UPDATE_DOWNLOAD_PROGRESS").apply {
+                                            setPackage(packageName)
                                             putExtra("progress", downloadedBytes.toFloat() / contentLength.toFloat())
                                             putExtra("version", version)
                                         }
@@ -284,6 +287,7 @@ class AppUpdateDownloadService : Service() {
                     // Send final progress
                     try {
                         val finalProgressIntent = Intent("ireader.UPDATE_DOWNLOAD_PROGRESS").apply {
+                            setPackage(packageName)
                             putExtra("progress", 1.0f)
                             putExtra("version", version)
                         }
@@ -310,6 +314,7 @@ class AppUpdateDownloadService : Service() {
                 // Broadcast completion
                 try {
                     val completionIntent = Intent("ireader.UPDATE_DOWNLOAD_COMPLETE").apply {
+                        setPackage(packageName)
                         putExtra("file_path", outputFile.absolutePath)
                         putExtra("version", version)
                     }
@@ -331,7 +336,9 @@ class AppUpdateDownloadService : Service() {
                 }
                 
                 try {
-                    val cancelIntent = Intent("ireader.UPDATE_DOWNLOAD_CANCELLED")
+                    val cancelIntent = Intent("ireader.UPDATE_DOWNLOAD_CANCELLED").apply {
+                        setPackage(packageName)
+                    }
                     sendBroadcast(cancelIntent)
                 } catch (broadcastError: Exception) {
                     // Continue anyway
@@ -360,6 +367,7 @@ class AppUpdateDownloadService : Service() {
                 
                 try {
                     val errorIntent = Intent("ireader.UPDATE_DOWNLOAD_ERROR").apply {
+                        setPackage(packageName)
                         putExtra("error", errorMessage)
                         putExtra("version", version)
                     }
@@ -381,7 +389,9 @@ class AppUpdateDownloadService : Service() {
         val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.notify(NOTIFICATION_ID, cancelNotification)
         
-        val cancelIntent = Intent("ireader.UPDATE_DOWNLOAD_CANCELLED")
+        val cancelIntent = Intent("ireader.UPDATE_DOWNLOAD_CANCELLED").apply {
+            setPackage(packageName)
+        }
         sendBroadcast(cancelIntent)
         
         stopSelf()

--- a/presentation/src/androidMain/kotlin/ireader/presentation/core/DownloadEventHandler.android.kt
+++ b/presentation/src/androidMain/kotlin/ireader/presentation/core/DownloadEventHandler.android.kt
@@ -18,14 +18,14 @@ actual class DownloadEventHandler actual constructor(
     private val receiver = AppUpdateDownloadReceiver(updateState)
     
     init {
-        // Register the broadcast receiver
-        // Note: RECEIVER_EXPORTED is required on Android 13+ because the download service
-        // sends implicit broadcasts via sendBroadcast(). RECEIVER_NOT_EXPORTED causes these
-        // broadcasts to be silently dropped on many OEM ROMs (Xiaomi/MIUI, Samsung, etc.),
-        // resulting in the UI showing 0% progress until the download completes.
+        // The download service sends package-explicit broadcasts (Intent.setPackage(packageName)),
+        // so this receiver is registered NOT_EXPORTED — the correct, secure pattern for
+        // app-internal broadcasts on Android 13+. Implicit (action-only) broadcasts were being
+        // dropped on Android 14+ and several OEM ROMs, which left the UI stuck at 0% until the
+        // download completed (issue #228).
         val filter = AppUpdateDownloadReceiver.createIntentFilter()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            context.registerReceiver(receiver, filter, Context.RECEIVER_EXPORTED)
+            context.registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED)
         } else {
             context.registerReceiver(receiver, filter)
         }


### PR DESCRIPTION
## Summary

Fixes the in-app updater's download progress bar staying stuck at 0% for the entire download and only jumping to 100% on completion (issue #228). Every download broadcast is now package-explicit, so the intermediate progress events are delivered reliably on modern Android.

## Why this matters

When a user triggers the in-app updater, the download itself works but the progress bar never moves until the very end. The maintainer confirmed this in the issue ("its working but the percentage is not showing"). A progress bar frozen at 0% looks like a hung or broken download, so users may cancel or retry unnecessarily, and there is no feedback that a large APK download is actually making progress.

The root cause is delivery-layer, not UI: `AppUpdateDownloadService` emits progress via `sendBroadcast(...)` with action-only (implicit) intents, e.g. `Intent("ireader.UPDATE_DOWNLOAD_PROGRESS")`. On Android 14+ (and several OEM ROMs such as Xiaomi/MIUI and Samsung) implicit app-internal broadcasts are unreliable and get dropped, so the frequent intermediate `PROGRESS` broadcasts never reach the receiver. The single terminal `COMPLETE` broadcast happens to land, which is why the bar sits at 0% and then jumps straight to 100%. `DownloadEventHandler.android.kt` had registered the receiver with `RECEIVER_EXPORTED` as an attempted workaround, but exporting the receiver does not make implicit broadcasts reliable and is an unnecessary security exposure.

## Changes

- Make every broadcast package-explicit by calling `intent.setPackage(packageName)` on all broadcasts in `AppUpdateDownloadService` (`CONNECTING`, `PROGRESS`, `COMPLETE`, `ERROR`, `CANCELLED`). Package-scoped broadcasts are delivered reliably to the app's own receiver on modern Android.
- Register the receiver with `RECEIVER_NOT_EXPORTED` instead of `RECEIVER_EXPORTED` on Android 13+, since the broadcasts are now package-scoped and no longer need to be exported. This is the documented-correct pattern for app-internal broadcasts and removes the exported-receiver security smell.

The change is limited to these two files and does not alter any download logic, notifications, or intent extras.

## Testing

- Trigger an update download on Android 14+: the progress bar now advances smoothly with intermediate percentages instead of jumping from 0% to 100%.
- The `ERROR` and `CANCELLED` broadcasts are package-scoped too, so the error/cancel UI states are still delivered.

Fixes #228
