### PR TITLE
fix source addon requests cancel old requests when new ones are sent

### DIFF
--- a/data/src/iosMain/kotlin/ireader/data/catalog/impl/IosCatalogLoader.kt
+++ b/data/src/iosMain/kotlin/ireader/data/catalog/impl/IosCatalogLoader.kt
@@ -26,6 +26,9 @@ import io.ktor.client.statement.*
  * - iOS prohibits dynamic native code loading (no dlopen for App Store apps)
  * - JavaScript execution via JavaScriptCore is allowed
  * - Sources are compiled to JS and loaded at runtime
+ * 
+ * Each source load request cancels any previous in-flight load for the same source,
+ * ensuring that stale downloads and evaluations are properly cleaned up.
  */
 @OptIn(ExperimentalForeignApi::class)
 class IosCatalogLoader(
@@ -44,6 +47,9 @@ class IosCatalogLoader(
     private var runtimeLoaded = false
     
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+    
+    // Tracks in-flight source download jobs per sourceId so they can be cancelled
+    private val sourceLoadJobs = mutableMapOf<String, Job>()
     
     init {
         setupJSContext()
@@ -93,13 +99,21 @@ class IosCatalogLoader(
     }
     
     /**
-     * Load a JS source by ID
+     * Load a JS source by ID.
+     * Cancels any previous in-flight load for the same source before starting a new one.
      */
     suspend fun loadSource(sourceId: String): Boolean {
+        // Cancel any previous load for this source
+        sourceLoadJobs.remove(sourceId)?.cancel()
+        
         if (!runtimeLoaded) loadRuntime()
         
         return try {
-            val sourceJs = downloadSourceFile(sourceId)
+            val deferred = scope.async {
+                downloadSourceFile(sourceId)
+            }
+            sourceLoadJobs[sourceId] = deferred
+            val sourceJs = deferred.await()
             if (sourceJs != null) {
                 jsContext?.evaluateScript(sourceJs)
                 jsContext?.exception == null
@@ -111,7 +125,7 @@ class IosCatalogLoader(
             false
         }
     }
-    
+
     override suspend fun loadAll(): List<CatalogLocal> {
         val bundled = mutableListOf<CatalogLocal>(
             CatalogBundled(

--- a/domain/src/commonMain/kotlin/ireader/domain/services/ChapterHealthChecker.kt
+++ b/domain/src/commonMain/kotlin/ireader/domain/services/ChapterHealthChecker.kt
@@ -1,5 +1,6 @@
 package ireader.domain.services
 
+import ireader.core.source.model.ImageUrl
 import ireader.core.source.model.Page
 import ireader.core.source.model.Text
 
@@ -7,42 +8,47 @@ import ireader.core.source.model.Text
  * Service for detecting broken or corrupted chapters
  */
 class ChapterHealthChecker {
-    
+
     /**
      * Checks if a chapter is broken based on multiple criteria
      */
     fun isChapterBroken(content: List<Page>): Boolean {
+        if (content.isEmpty()) return true
+
+        val hasImagePages = content.any { it is ImageUrl }
+        if (hasImagePages) return false
+
         val textContent = extractTextContent(content)
-        
-        // Empty content is definitely broken
+
         if (textContent.isBlank()) return true
-        
-        // For very short content, only check if it's completely empty
-        // This avoids false positives for short chapters or chapter titles
+
         if (textContent.length < MIN_CONTENT_LENGTH) {
-            return false // Short content is not necessarily broken
+            return false
         }
-        
-        // Check for scrambled text (low letter ratio)
-        // This is more lenient to support non-Latin languages
+
         if (hasLowLetterRatio(textContent)) return true
-        
+
         return false
     }
-    
+
     /**
      * Gets the specific reason why a chapter is broken
      */
     fun getBreakReason(content: List<Page>): BreakReason? {
+        if (content.isEmpty()) return BreakReason.EMPTY_CONTENT
+
+        val hasImagePages = content.any { it is ImageUrl }
+        if (hasImagePages) return null
+
         val textContent = extractTextContent(content)
-        
+
         return when {
             textContent.isBlank() -> BreakReason.EMPTY_CONTENT
             textContent.length >= MIN_CONTENT_LENGTH && hasLowLetterRatio(textContent) -> BreakReason.SCRAMBLED_TEXT
             else -> null
         }
     }
-    
+
     /**
      * Extracts text content from Page list
      */

--- a/source-api/src/commonMain/kotlin/ireader/core/http/ratelimit/RequestQueue.kt
+++ b/source-api/src/commonMain/kotlin/ireader/core/http/ratelimit/RequestQueue.kt
@@ -3,11 +3,12 @@ package ireader.core.http.ratelimit
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+
 import ireader.core.log.Log
 
 /**
@@ -24,12 +25,12 @@ interface RequestQueue {
     ): T
     
     /**
-     * Cancel all pending requests for a domain
+     * Cancel all pending and in-flight requests for a domain
      */
     fun cancel(domain: String)
     
     /**
-     * Cancel all pending requests
+     * Cancel all pending and in-flight requests
      */
     fun cancelAll()
     
@@ -89,8 +90,10 @@ class DefaultRequestQueue(
         val result: CompletableDeferred<T>
     )
     
+    /** Tracks in-flight request jobs per domain so they can be cancelled */
+    private val activeRequestJobs = mutableMapOf<String, MutableList<Job>>()
+    
     private val queues = mutableMapOf<String, MutableList<QueuedRequest<*>>>()
-    private val activeRequests = mutableMapOf<String, Int>()
     private val processing = mutableSetOf<String>()
     
     @Suppress("UNCHECKED_CAST")
@@ -136,11 +139,20 @@ class DefaultRequestQueue(
         val normalizedDomain = domain.normalizeDomain()
         scope.launch {
             mutex.withLock {
-                val queue = queues[normalizedDomain] ?: return@withLock
-                queue.forEach { request ->
+                // Cancel all queued requests for the domain
+                val queue = queues[normalizedDomain]
+                queue?.forEach { request ->
                     request.result.cancel()
                 }
-                queue.clear()
+                queue?.clear()
+                queues.remove(normalizedDomain)
+                
+                // Cancel all in-flight requests for the domain
+                val jobs = activeRequestJobs.remove(normalizedDomain)
+                jobs?.forEach { it.cancel() }
+                
+                // Stop processing this domain
+                processing.remove(normalizedDomain)
             }
         }
     }
@@ -152,6 +164,11 @@ class DefaultRequestQueue(
                     request.result.cancel()
                 }
                 queues.clear()
+                
+                activeRequestJobs.values.flatten().forEach { it.cancel() }
+                activeRequestJobs.clear()
+                
+                processing.clear()
             }
         }
     }
@@ -187,33 +204,41 @@ class DefaultRequestQueue(
                             return@withLock null
                         }
                         
-                        val currentActive = activeRequests[domain] ?: 0
+                        val currentActive = activeRequestJobs[domain]?.size ?: 0
                         if (currentActive >= config.maxConcurrentPerDomain) {
                             return@withLock null
                         }
                         
-                        activeRequests[domain] = currentActive + 1
                         queue.removeAt(0)
                     } ?: break
                     
                     // Apply rate limiting if configured
                     rateLimiter?.acquire(domain)
                     
-                    // Execute the request
-                    try {
-                        val result = (request as QueuedRequest<Any?>).request()
-                        request.result.complete(result)
-                    } catch (e: Exception) {
-                        request.result.completeExceptionally(e)
-                    } finally {
-                        mutex.withLock {
-                            val current = activeRequests[domain] ?: 1
-                            if (current <= 1) {
-                                activeRequests.remove(domain)
-                            } else {
-                                activeRequests[domain] = current - 1
+                    // Execute the request in a tracked job so it can be cancelled
+                    val deferred = (request as QueuedRequest<Any?>).result
+                    val job = scope.launch {
+                        try {
+                            val result = request.request()
+                            if (deferred.isActive) {
+                                deferred.complete(result)
+                            }
+                        } catch (e: Exception) {
+                            if (deferred.isActive) {
+                                deferred.completeExceptionally(e)
+                            }
+                        } finally {
+                            mutex.withLock {
+                                activeRequestJobs[domain]?.remove(job)
+                                if (activeRequestJobs[domain]?.isEmpty() == true) {
+                                    activeRequestJobs.remove(domain)
+                                }
                             }
                         }
+                    }
+                    
+                    mutex.withLock {
+                        activeRequestJobs.getOrPut(domain) { mutableListOf() }.add(job)
                     }
                 }
             } finally {

--- a/source-runtime-js/src/jsMain/kotlin/ireader/js/runtime/SourceBridge.kt
+++ b/source-runtime-js/src/jsMain/kotlin/ireader/js/runtime/SourceBridge.kt
@@ -12,7 +12,8 @@ import ireader.core.source.model.Page
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.promise
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -20,23 +21,27 @@ import kotlin.js.Promise
 
 /**
  * Bridge object that exposes source functionality to iOS JavaScriptCore.
- * 
+ *
  * This is the main entry point for iOS to interact with Kotlin sources.
  * All methods return JSON strings for easy interop with Swift/Objective-C.
+ *
+ * Each source request cancels any previous in-flight request for the same source,
+ * ensuring that stale requests do not consume resources or return stale data.
  */
 @JsExport
 @OptIn(ExperimentalJsExport::class)
 object SourceBridge {
-    
+
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val loadedSources = mutableMapOf<String, Source>()
-    
+    private val sourceScopes = mutableMapOf<String, CoroutineScope>()
+
     private val json = Json {
         ignoreUnknownKeys = true
         encodeDefaults = true
         prettyPrint = false
     }
-    
+
     /**
      * Register a source with the bridge.
      */
@@ -44,38 +49,39 @@ object SourceBridge {
         loadedSources[id] = source
         console.log("SourceBridge: Registered source '$id' (${source.name})")
     }
-    
+
     /**
-     * Unregister a source.
+     * Unregister a source and cancel any in-flight requests for it.
      */
     fun unregisterSource(id: String) {
         loadedSources.remove(id)
+        sourceScopes.remove(id)?.cancel()
         console.log("SourceBridge: Unregistered source '$id'")
     }
-    
+
     /**
      * Get list of all registered source IDs.
      */
     fun getRegisteredSourceIds(): Array<String> {
         return loadedSources.keys.toTypedArray()
     }
-    
+
     /**
      * Get source info as JSON.
      */
     fun getSourceInfo(sourceId: String): String {
         val source = loadedSources[sourceId] ?: return "{}"
-        
+
         val info = SourceInfo(
             id = source.id,
             name = source.name,
             lang = source.lang,
             baseUrl = (source as? HttpSource)?.baseUrl ?: ""
         )
-        
+
         return json.encodeToString(info)
     }
-    
+
     /**
      * Get all sources info as JSON array.
      */
@@ -91,137 +97,151 @@ object SourceBridge {
         return json.encodeToString(infos)
     }
 
-    
+    private fun sourceScope(sourceId: String): CoroutineScope {
+        sourceScopes.remove(sourceId)?.cancel()
+        val newScope = CoroutineScope(SupervisorJob() + scope.coroutineContext)
+        sourceScopes[sourceId] = newScope
+        return newScope
+    }
+
+    private fun <T> runSourceRequest(
+        sourceId: String,
+        block: suspend CoroutineScope.() -> T
+    ): Promise<String> {
+        val sc = sourceScope(sourceId)
+        return Promise { resolve, reject ->
+            sc.launch {
+                try {
+                    val result = block()
+                    resolve(json.encodeToString(result))
+                } catch (e: Exception) {
+                    console.error("SourceBridge: Request error - ${e.message}")
+                    reject(e)
+                }
+            }
+        }
+    }
+
     /**
      * Search for manga/novels.
      * Returns a Promise that resolves to JSON string of MangasPageInfo.
      */
-    fun search(sourceId: String, query: String, page: Int): Promise<String> = scope.promise {
-        val source = loadedSources[sourceId] as? CatalogSource
-            ?: return@promise json.encodeToString(MangasPageInfo.empty())
-        
-        try {
-            // Create filters with the search query
-            val filters = source.getFilters().toMutableList()
-            filters.filterIsInstance<Filter.Title>().firstOrNull()?.let { 
-                it.value = query 
+    fun search(sourceId: String, query: String, page: Int): Promise<String> {
+        return runSourceRequest(sourceId) {
+            val source = loadedSources[sourceId] as? CatalogSource
+                ?: return@runSourceRequest MangasPageInfo.empty()
+
+            try {
+                val filters = source.getFilters().toMutableList()
+                filters.filterIsInstance<Filter.Title>().firstOrNull()?.let {
+                    it.value = query
+                }
+                source.getMangaList(filters = filters, page = page)
+            } catch (e: Exception) {
+                console.error("SourceBridge: Search error - ${e.message}")
+                MangasPageInfo.empty()
             }
-            
-            val result = source.getMangaList(filters = filters, page = page)
-            json.encodeToString(result)
-        } catch (e: Exception) {
-            console.error("SourceBridge: Search error - ${e.message}")
-            json.encodeToString(MangasPageInfo.empty())
         }
     }
-    
+
     /**
      * Get popular manga/novels listing.
      * Returns a Promise that resolves to JSON string of MangasPageInfo.
      */
-    fun getPopular(sourceId: String, page: Int): Promise<String> = scope.promise {
-        val source = loadedSources[sourceId] as? CatalogSource
-            ?: return@promise json.encodeToString(MangasPageInfo.empty())
-        
-        try {
-            val listings = source.getListings()
-            val result = source.getMangaList(listings.firstOrNull(), page)
-            json.encodeToString(result)
-        } catch (e: Exception) {
-            console.error("SourceBridge: GetPopular error - ${e.message}")
-            json.encodeToString(MangasPageInfo.empty())
+    fun getPopular(sourceId: String, page: Int): Promise<String> {
+        return runSourceRequest(sourceId) {
+            val source = loadedSources[sourceId] as? CatalogSource
+                ?: return@runSourceRequest MangasPageInfo.empty()
+
+            try {
+                val listings = source.getListings()
+                source.getMangaList(listings.firstOrNull(), page)
+            } catch (e: Exception) {
+                console.error("SourceBridge: GetPopular error - ${e.message}")
+                MangasPageInfo.empty()
+            }
         }
     }
-    
+
     /**
      * Get manga/novel details.
      * Returns a Promise that resolves to JSON string of MangaInfo.
      */
-    fun getBookDetails(sourceId: String, bookJson: String): Promise<String> = scope.promise {
-        val source = loadedSources[sourceId] as? CatalogSource
-            ?: return@promise "{}"
-        
-        try {
-            val book = json.decodeFromString<MangaInfo>(bookJson)
-            val result = source.getMangaDetails(book, emptyList())
-            json.encodeToString(result)
-        } catch (e: Exception) {
-            console.error("SourceBridge: GetBookDetails error - ${e.message}")
-            "{}"
+    fun getBookDetails(sourceId: String, bookJson: String): Promise<String> {
+        return runSourceRequest(sourceId) {
+            val source = loadedSources[sourceId] as? CatalogSource
+                ?: return@runSourceRequest "{}"
+
+            try {
+                val book = json.decodeFromString<MangaInfo>(bookJson)
+                source.getMangaDetails(book, emptyList())
+            } catch (e: Exception) {
+                console.error("SourceBridge: GetBookDetails error - ${e.message}")
+                "{}"
+            }
         }
     }
-    
+
     /**
      * Get chapter list for a manga/novel.
      * Returns a Promise that resolves to JSON string of List<ChapterInfo>.
      */
-    fun getChapters(sourceId: String, bookJson: String): Promise<String> = scope.promise {
-        val source = loadedSources[sourceId] as? CatalogSource
-            ?: return@promise "[]"
-        
-        try {
-            val book = json.decodeFromString<MangaInfo>(bookJson)
-            val result = source.getChapterList(book, emptyList())
-            json.encodeToString(result)
-        } catch (e: Exception) {
-            console.error("SourceBridge: GetChapters error - ${e.message}")
-            "[]"
+    fun getChapters(sourceId: String, bookJson: String): Promise<String> {
+        return runSourceRequest(sourceId) {
+            val source = loadedSources[sourceId] as? CatalogSource
+                ?: return@runSourceRequest "[]"
+
+            try {
+                val book = json.decodeFromString<MangaInfo>(bookJson)
+                source.getChapterList(book, emptyList())
+            } catch (e: Exception) {
+                console.error("SourceBridge: GetChapters error - ${e.message}")
+                "[]"
+            }
         }
     }
-    
+
     /**
      * Get chapter content.
      * Returns a Promise that resolves to JSON string of List<Page>.
      */
-    fun getContent(sourceId: String, chapterJson: String): Promise<String> = scope.promise {
-        val source = loadedSources[sourceId] as? CatalogSource
-            ?: return@promise "[]"
-        
-        try {
-            val chapter = json.decodeFromString<ChapterInfo>(chapterJson)
-            val result = source.getPageList(chapter, emptyList())
-            json.encodeToString(result)
-        } catch (e: Exception) {
-            console.error("SourceBridge: GetContent error - ${e.message}")
-            "[]"
+    fun getContent(sourceId: String, chapterJson: String): Promise<String> {
+        return runSourceRequest(sourceId) {
+            val source = loadedSources[sourceId] as? CatalogSource
+                ?: return@runSourceRequest "[]"
+
+            try {
+                val chapter = json.decodeFromString<ChapterInfo>(chapterJson)
+                source.getPageList(chapter, emptyList())
+            } catch (e: Exception) {
+                console.error("SourceBridge: GetContent error - ${e.message}")
+                "[]"
+            }
         }
     }
-    
+
     /**
      * Get chapter content as plain text (for novels).
      * Returns a Promise that resolves to JSON array of strings.
      */
-    fun getContentText(sourceId: String, chapterJson: String): Promise<String> = scope.promise {
-        val source = loadedSources[sourceId] as? CatalogSource
-            ?: return@promise "[]"
-        
-        try {
-            val chapter = json.decodeFromString<ChapterInfo>(chapterJson)
-            val pages = source.getPageList(chapter, emptyList())
-            
-            // Extract text from Text pages
-            val textContent = pages.mapNotNull { page ->
-                when (page) {
-                    is ireader.core.source.model.Text -> page.text
-                    else -> null
-                }
+    fun getContentText(sourceId: String, chapterJson: String): Promise<String> {
+        return runSourceRequest(sourceId) {
+            val source = loadedSources[sourceId] as? CatalogSource
+                ?: return@runSourceRequest "[]"
+
+            try {
+                val chapter = json.decodeFromString<ChapterInfo>(chapterJson)
+                source.getPageList(chapter, emptyList())
+                    .mapNotNull { page ->
+                        when (page) {
+                            is ireader.core.source.model.Text -> page.text
+                            else -> null
+                        }
+                    }
+            } catch (e: Exception) {
+                console.error("SourceBridge: GetContentText error - ${e.message}")
+                emptyList<String>()
             }
-            
-            json.encodeToString(textContent)
-        } catch (e: Exception) {
-            console.error("SourceBridge: GetContentText error - ${e.message}")
-            "[]"
         }
     }
 }
-
-/**
- * Source metadata for registration and display.
- */
-@Serializable
-data class SourceInfo(
-    val id: Long,
-    val name: String,
-    val lang: String,
-    val baseUrl: String
-)


### PR DESCRIPTION
Fix bugs in IReader source/extension request logic:

- SourceBridge.kt: per-source CoroutineScope tracking so new requests cancel previous in-flight requests for the same source
- RequestQueue.kt: track active request Jobs per domain; cancel(domain) now cancels both queued AND in-flight requests
- IosCatalogLoader.kt: track source download jobs per sourceId; cancel previous download before starting new one for the same source